### PR TITLE
#167556576 create graph for data from thingspeak api

### DIFF
--- a/assets/css/all.css
+++ b/assets/css/all.css
@@ -4390,3 +4390,70 @@ readers do not read off random characters that represent icons */
 .fas {
   font-family: 'Font Awesome 5 Free';
   font-weight: 900; }
+div#chrona {
+  width: 800px;
+  height: 600px;
+  margin: auto;
+  background-color: white;
+}
+
+svg {
+  width: 800px;
+  height: 800px;
+}
+
+.bar {
+  fill: #80cbc4;
+}
+
+text {
+  font-size: 12px;
+  fill: grey;
+}
+
+path {
+  stroke: gray;
+}
+
+line {
+  stroke: gray;
+}
+
+line#limit {
+  stroke: #FED966;
+  stroke-width: 3;
+  stroke-dasharray: 3 6;
+}
+
+.grid path {
+  stroke-width: 0;
+}
+
+.grid .tick line {
+  stroke: #9FAAAE;
+  stroke-opacity: 0.3;
+}
+
+text.divergence {
+  font-size: 14px;
+  fill: #2F4A6D;
+}
+
+text.value {
+  font-size: 14px;
+}
+
+text.title {
+  font-size: 22px;
+  font-weight: 600;
+}
+
+text.label {
+  font-size: 14px;
+  font-weight: 400;
+  color: white;
+}
+
+text.source {
+  font-size: 10px;
+}

--- a/iot_dashboard/apps/dashboard/services.py
+++ b/iot_dashboard/apps/dashboard/services.py
@@ -4,9 +4,28 @@ import requests
 def get_channel():
     url = 'https://api.thingspeak.com/channels/9/feeds.json'
     params = {
-        'timescale': 5
+        'results': 20
     }
     r = requests.get(url, params=params)
     data = r.json()
-    channel = data['feeds']
-    return channel
+    feeds = data['feeds']
+    index = 1
+    feed_data = {}
+    light_feeds = []
+    temperature_feeds = []
+    for feed in feeds:
+        light_feed = {
+            'home': index,
+            'value': round(float(feed['field1']), 2)
+        }
+        light_feeds.append(light_feed)
+        temperature_feed = {
+            'home': index,
+            'value': round(float(feed['field2']), 2)
+        }
+        temperature_feeds.append(temperature_feed)
+        index += 1
+    feed_data['light'] = light_feeds
+    feed_data['temperature'] = temperature_feeds
+    feed_data['results'] = params['results']
+    return feed_data

--- a/iot_dashboard/apps/dashboard/views.py
+++ b/iot_dashboard/apps/dashboard/views.py
@@ -10,6 +10,10 @@ CACHE_TTL = getattr(settings, 'CACHE_TTL', DEFAULT_TIMEOUT)
 
 
 @login_required
-@cache_page(CACHE_TTL)
+# @cache_page(CACHE_TTL)
 def dashboard(request):
-    return render(request, 'dashboard/index.html', {'feeds': get_channel()})
+    feed_data = get_channel()
+    light = feed_data['light']
+    temperature = feed_data['temperature']
+    results = feed_data['results']
+    return render(request, 'dashboard/index.html', {'light': light, 'temperature': temperature, 'results': results})

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,13 +12,11 @@
 </head>
 
 <body class="bg-light">
-    {% block content %}{% endblock %}
+{% block content %}{% endblock %}
 
     <script src="{% static 'js/jquery.min.js' %}"></script>
     <script src="{% static 'js/bootstrap.js' %}"></script>
-    <script src="{% static 'js/bootstrap-tagsinput.js' %}">
-        $("input").tagsinput('items')
-    </script>
+    <script src="https://d3js.org/d3.v5.min.js"></script>
 </body>
 
 </html>

--- a/templates/dashboard/index.html
+++ b/templates/dashboard/index.html
@@ -12,12 +12,97 @@
             </div>
         </div>
         <div class="col-8">
-            {% for feed in feeds %}
-            <p>{{feed}}</p>
-            {% endfor %}
+            <div id="chrona">
+                <svg />
+            </div>
         </div>
         <div class="col-2"></div>
     </div>
 
 </div>
+<script src="https://d3js.org/d3.v5.min.js"></script>
+<script>
+    // https://insights.stackoverflow.com/survey/2018/#technology-most-loved-dreaded-and-wanted-languages
+    const sample = {{temperature | safe}};
+
+    const svg = d3.select('svg');
+    const svgContainer = d3.select('#chrona');
+
+    const margin = 80;
+    const width = 800 - 2 * margin;
+    const height = 600 - 2 * margin;
+
+    const chart = svg.append('g')
+      .attr('transform', `translate(${margin}, ${margin})`);
+
+    const xScale = d3.scaleBand()
+      .range([0, width])
+      .domain(sample.map((s) => s.home))
+      .padding(0.4)
+
+    const yScale = d3.scaleLinear()
+      .range([height, 0])
+      .domain([0, 100]);
+
+    const makeYLines = () => d3.axisLeft()
+      .scale(yScale)
+
+    chart.append('g')
+      .attr('transform', `translate(0, ${height})`)
+      .call(d3.axisBottom(xScale));
+
+    chart.append('g')
+      .call(d3.axisLeft(yScale));
+
+    chart.append('g')
+      .attr('class', 'grid')
+      .call(makeYLines()
+        .tickSize(-width, 0, 0)
+        .tickFormat('')
+      )
+
+    const barGroups = chart.selectAll()
+      .data(sample)
+      .enter()
+      .append('g')
+
+    barGroups
+      .append('rect')
+      .attr('class', 'bar')
+      .attr('x', (g) => xScale(g.home))
+      .attr('y', (g) => yScale(g.value))
+      .attr('height', (g) => height - yScale(g.value))
+      .attr('width', xScale.bandwidth())
+
+    svg
+      .append('text')
+      .attr('class', 'label')
+      .attr('x', -(height / 2) - margin)
+      .attr('y', margin / 2.4)
+      .attr('transform', 'rotate(-90)')
+      .attr('text-anchor', 'middle')
+      .text('Temperatures (° C)');
+
+    svg.append('text')
+      .attr('class', 'label')
+      .attr('x', width / 2 + margin)
+      .attr('y', height + margin * 1.7)
+      .attr('text-anchor', 'middle')
+      .text('House Number');
+
+    svg.append('text')
+      .attr('class', 'title')
+      .attr('x', width / 2 + margin)
+      .attr('y', 40)
+      .attr('text-anchor', 'middle')
+      .text('Average Outside Temperature readings');
+
+    svg.append('text')
+      .attr('class', 'source')
+      .attr('x', width - margin / 2)
+      .attr('y', height + margin * 1.7)
+      .attr('text-anchor', 'start')
+      .text('Source: ThingSpeak API')
+
+</script>
 {% endblock %}


### PR DESCRIPTION
 **What does this PR do?**
This PR ensures that the application can display a graph showing data consumed from the thingspeak API.

**Description of Task to be completed?**
- add d3.js in base.html
- add script to create the graphs in base.html file

**What are the relevant Pivotal Tracker stories?**
[#167556576](https://www.pivotaltracker.com/n/projects/2364284/stories/167556576)

**How should be tested manually?**
Run each of the following commands in your terminal in the respective order.

- `git clone https://github.com/fahadmak/stackoverflow_clone.git`
- `cd django_iot_dashboard`
- `git checkout ft-user-authentication-167556577`
- `virtualenv venv`
- `. venv/bin/activate`
- `pip install -r requirements.txt`
- `run migrations using this command python manage.py migrate`
- `run python manage.py runserver 127.0.0.1:8000`
- `Go to this link in your browser 127.0.0.1:8000`
- `You will be redirected to the login page where you should log in`
- `After login, you will be redirected to dashboard to view data from the API`

**Screenshots**
<img width="1021" alt="Room Availability - 600dp After" src="https://user-images.githubusercontent.com/13882936/62546185-b5a4d200-b86b-11e9-9735-d634618a85bc.png">